### PR TITLE
Adding Vega-Lite to compound object

### DIFF
--- a/_includes/item/child/compound-item-modal-gallery.html
+++ b/_includes/item/child/compound-item-modal-gallery.html
@@ -101,6 +101,8 @@
                                                         </div>
                                                     {% elsif child.display_template == 'panorama' %}
                                                         {% include item/child/panorama.html %}
+                                                    {% elsif child.display_template == 'data-visualization' %}
+                                                        {% include item/child/vegalite-reader.html  %}
                                                     {% else %}
                                                         {% include item/child/item-thumb.html %}
                                                     {% endif %}

--- a/_includes/item/child/vegalite-reader.html
+++ b/_includes/item/child/vegalite-reader.html
@@ -3,8 +3,8 @@
     <div id="vis"></div>
     <script>
       (function(vegaEmbed) {
-        // var spec = "{{child.object_location}}";
-        var spec = "https://raw.githubusercontent.com/ers6/ia_scanning_labor_data/main/center_visuals/allen_county_public_library_geneaology_center/scans_per_month.json";
+       var spec = "{{child.object_location}}";
+       // var spec = "https://raw.githubusercontent.com/ers6/ia_scanning_labor_data/main/center_visuals/allen_county_public_library_geneaology_center/scans_per_month.json";
         var embedOpt = {"mode": "vega-lite"};
     
         function showError(el, error){


### PR DESCRIPTION
This simply does what I described in Slack @ers6 -- adds an elsif to the compound modal gallery to ensure it pulls in vega-lite if display template is 'data-visualization'